### PR TITLE
Prefix references to namespace `std` with ::

### DIFF
--- a/include/boost/lambda2/lambda2.hpp
+++ b/include/boost/lambda2/lambda2.hpp
@@ -17,16 +17,16 @@ namespace lambda2
 namespace detail
 {
 
-template<class T> using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+template<class T> using remove_cvref_t = ::std::remove_cv_t<::std::remove_reference_t<T>>;
 
 template<class T, class T2 = remove_cvref_t<T>> using is_lambda_expression =
-    std::integral_constant<bool, std::is_placeholder<T2>::value || std::is_bind_expression<T2>::value>;
+    ::std::integral_constant<bool, ::std::is_placeholder<T2>::value || ::std::is_bind_expression<T2>::value>;
 
 template<class A> using enable_unary_lambda =
-    std::enable_if_t<is_lambda_expression<A>::value>;
+    ::std::enable_if_t<is_lambda_expression<A>::value>;
 
 template<class A, class B> using enable_binary_lambda =
-    std::enable_if_t<is_lambda_expression<A>::value || is_lambda_expression<B>::value>;
+    ::std::enable_if_t<is_lambda_expression<A>::value || is_lambda_expression<B>::value>;
 
 } // namespace detail
 
@@ -34,14 +34,14 @@ template<class A, class B> using enable_binary_lambda =
     template<class A, class = detail::enable_unary_lambda<A>> \
     auto operator op( A&& a ) \
     { \
-        return std::bind( std::fn<>(), std::forward<A>(a) ); \
+        return ::std::bind( ::std::fn<>(), ::std::forward<A>(a) ); \
     }
 
 #define BOOST_LAMBDA2_BINARY_LAMBDA(op, fn) \
     template<class A, class B, class = detail::enable_binary_lambda<A, B>> \
     auto operator op( A&& a, B&& b ) \
     { \
-        return std::bind( std::fn<>(), std::forward<A>(a), std::forward<B>(b) ); \
+        return ::std::bind( ::std::fn<>(), ::std::forward<A>(a), ::std::forward<B>(b) ); \
     }
 
 BOOST_LAMBDA2_BINARY_LAMBDA(+, plus)
@@ -70,7 +70,7 @@ BOOST_LAMBDA2_UNARY_LAMBDA(~, bit_not)
 #undef BOOST_LAMBDA2_UNARY_LAMBDA
 #undef BOOST_LAMBDA2_BINARY_LAMBDA
 
-using namespace std::placeholders;
+using namespace ::std::placeholders;
 
 } // namespace lambda2
 } // namespace boost


### PR DESCRIPTION
Just in case the user has a nested namespace `std` that could ADL-interact with your implementation.